### PR TITLE
Fix Discourse blocking Sentry library in browser

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-sentry.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-sentry.js.es6
@@ -1,38 +1,38 @@
-import { withPluginApi } from "discourse/lib/plugin-api";
+import { withPluginApi } from 'discourse/lib/plugin-api'
 
 export default {
-  name: "discourse-sentry",
+  name: 'discourse-sentry',
 
   initialize() {
-    withPluginApi("0.8.24", () => {
-      const src = "https://browser.sentry-cdn.com/4.5.4/bundle.min.js";
-      const enabled = Discourse.SiteSettings.discourse_sentry_enabled;
-      const dsn = Discourse.SiteSettings.discourse_sentry_dsn;
+    withPluginApi('0.8.24', () => {
+      const src = 'https://browser.sentry-cdn.com/5.11.1/bundle.min.js'
+      const enabled = Discourse.SiteSettings.discourse_sentry_enabled
+      const dsn = Discourse.SiteSettings.discourse_sentry_dsn
 
       if (!enabled || !dsn) {
-        return;
+        return
       }
 
-      const script = document.createElement("script");
+      const script = document.createElement('script')
 
       script.onload = () => {
         window.Sentry.init({
           dsn
-        });
+        })
 
-        const currentUser = Discourse.User.current();
+        const currentUser = Discourse.User.current()
 
         if (currentUser) {
-          const { id, username } = currentUser;
+          const { id, username } = currentUser
 
           window.Sentry.configureScope(scope => {
-            scope.setUser({ id, username });
-          });
+            scope.setUser({ id, username })
+          })
         }
-      };
+      }
 
-      script.src = src;
-      document.head.appendChild(script);
-    });
+      script.src = src
+      document.head.appendChild(script)
+    })
   }
-};
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,10 +1,10 @@
 # name: discourse-sentry
 # about: Discourse plugin to integrate Sentry (sentry.io)
-# version: 1.0
+# version: 1.1
 # authors: debtcollective
 # url: https://github.com/debtcollective/discourse-sentry
 
-gem "sentry-raven", "2.9.0"
+gem "sentry-raven", "2.13.0"
 
 enabled_site_setting :discourse_sentry_enabled
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # name: discourse-sentry
 # about: Discourse plugin to integrate Sentry (sentry.io)
 # version: 1.1
@@ -26,5 +27,9 @@ after_initialize do
         Raven.extra_context(params: params.to_unsafe_h, url: request.url)
       end
     end
+
+    extend_content_security_policy(
+      script_src: ['https://browser.sentry-cdn.com/5.11.1/bundle.min.js']
+    )
   end
 end


### PR DESCRIPTION
**What:** Fix Discourse blocking Sentry library in browser

**Why:** Closes https://github.com/debtcollective/community/issues/31

**How:**

Discourse added CSP enforcing only local resources to be loaded. https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243

We are adding an extension to their policy to allow Sentry to be loaded as recommended here https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243#third-party-script-service-integration