### PR TITLE
FIX: `Discourse.User` is deprecated

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-sentry.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-sentry.js.es6
@@ -6,7 +6,7 @@ export default {
   name: 'discourse-sentry',
 
   initialize() {
-    withPluginApi('0.8.24', () => {
+    withPluginApi('0.8.24', api => {
       const src = `https://browser.sentry-cdn.com/${sentryBrowserVersion}/bundle.min.js`
       const enabled = Discourse.SiteSettings.discourse_sentry_enabled
       const dsn = Discourse.SiteSettings.discourse_sentry_dsn
@@ -22,7 +22,7 @@ export default {
           dsn,
         })
 
-        const currentUser = Discourse.User.current()
+        const currentUser = api.getCurrentUser();
 
         if (currentUser) {
           const { id, username } = currentUser


### PR DESCRIPTION
**What:** This fixes a deprecation

**Why:** To allow discourse to continue to work in the future

**How:** By using `api.getCurrentUser` instead.
